### PR TITLE
Ft user delete meetup 163345526

### DIFF
--- a/app/admin/models.py
+++ b/app/admin/models.py
@@ -81,24 +81,24 @@ class MeetupModel:
 
     #delete a specific meetup
     @staticmethod
-    def delete_specific_meetup(meet_id):
+    def delete_specific_meetup(meeting_id):
         """
         found = None
         for meetup in MEETUPS_LEN:
-            if meetup.id == meet_id:
+            if meetup.id == meeting_id:
                 MEETUPS_LEN.remove(meetup)
                 found = True
-            elif meetup.id != meet_id:
+            elif meetup.id != meeting_id:
                 found = False
         return found
         """
 
-        meetup = MeetupModel.get_meetup(meet_id)
+        meetup = MeetupModel.get_meetup(meeting_id)
 
         if meetup:
             query = """
             DELETE FROM meetups
-            WHERE meetups.meetup_id = '{}'""".format(meet_id)
+            WHERE meetups.meetup_id = '{}'""".format(meeting_id)
 
             db.query_db_no_return(query)
             return True

--- a/app/admin/models.py
+++ b/app/admin/models.py
@@ -93,7 +93,7 @@ class MeetupModel:
         return found
         """
 
-        meetup = MeetupModel.get_meetup(meeting_id)
+        meetup = MeetupModel.get_specific_meetup(meeting_id)
 
         if meetup:
             query = """

--- a/app/admin/models.py
+++ b/app/admin/models.py
@@ -92,7 +92,7 @@ class MeetupModel:
                 found = False
         return found
         """
-
+        #get specific meetup
         meetup = MeetupModel.get_specific_meetup(meeting_id)
 
         if meetup:

--- a/app/api/v2/admin/routes.py
+++ b/app/api/v2/admin/routes.py
@@ -125,7 +125,16 @@ def meetup_rsvp(meetup_id, resp):
 @path_2.route("/meetups/<int:meetup_id>", methods=['DELETE'])
 @token_required
 def admin_delete_a_meetup(meetup_id):
+    admin = utils.check_if_user_is_admin()
+    if not admin:
+        return jsonify({
+            'status': 401,
+            'error':"You are not allowed to perfom this function"}), 401
+
     deleted = MeetupModel.delete_specific_meetup(meetup_id)
+
     if deleted:
         return jsonify({'status': 200, 'data':"Meetup record deleted successfully"}), 200
-    return jsonify({'status': 404, 'data':"Meetup with id {} not found".format(meetup_id)}), 404
+    return jsonify({
+        'status': 404,
+        'data':"Meetup with id {} not found".format(meetup_id)}), 404

--- a/app/api/v2/admin/routes.py
+++ b/app/api/v2/admin/routes.py
@@ -127,5 +127,5 @@ def meetup_rsvp(meetup_id, resp):
 def admin_delete_a_meetup(meetup_id):
     deleted = MeetupModel.delete_specific_meetup(meetup_id)
     if deleted:
-        return jsonify({'status': 200, 'data':"Deleted successfully"}), 200
+        return jsonify({'status': 200, 'data':"Meetup record deleted successfully"}), 200
     return jsonify({'status': 404, 'data':"Meetup with id {} not found".format(meetup_id)}), 404

--- a/app/api/v2/admin/routes.py
+++ b/app/api/v2/admin/routes.py
@@ -124,7 +124,7 @@ def meetup_rsvp(meetup_id, resp):
 #admin delete meetup
 @path_2.route("/meetups/<int:meetup_id>", methods=['DELETE'])
 @token_required
-def admin_delete_a_meetup(meetup_id):
+def admin_delete_a_meetup(current_user, meetup_id):
     admin = utils.check_if_user_is_admin()
     if not admin:
         return jsonify({

--- a/tests/test_meetups.py
+++ b/tests/test_meetups.py
@@ -264,3 +264,18 @@ class TestMeetupsRecords(MeetupsBaseTest):
         self.assertEqual(result["status"], 200)
         self.assertTrue(result["data"])
 
+    #tests admin can delete a meetup record
+    def test_admin_can_delete_a_meetup_record(self):
+        self.token = self.user_login()
+        self.client.post("api/v2/meetups",
+                         data=json.dumps(self.post_meetup1),
+                         headers={'x-access-token': self.token},
+                         content_type="application/json")
+        response = self.client.delete("api/v2/meetups/1",
+                                      headers={'x-access-token': self.token},
+                                      content_type="application/json")
+        result = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(result["status"], 200)
+        self.assertEqual(result["data"], "Meetup record deleted successfully")
+


### PR DESCRIPTION
**What does this PR do?**
 Enables an admin to delete a specific meetup record
Only an admin should be able to delete a meetup record

**Description of task to be completed?**
Create tests for admin delete meetup record
Create the API endpoint for admin delete meetup record
Modify tests to pass

**How should you manually test this?**
Clone the repo `git clone https://github.com/blairt001/Questioner-API-V2.git`
cd into the project folder
Activate virtual env: `source/bin/activate`
Run the application: `python manage.py runserver`
Use POSTMAN to test the `DELETE` API endpoint: `http://127.0.0.1:5000/api/v2/meetups/1`
On the terminal, run : ` pytest tests/test_meetups.py`

**What are the relevant PT stories?**
https://www.pivotaltracker.com/story/show/163345526
#163345526

![delete_meetup_test](https://user-images.githubusercontent.com/46051026/51439807-a182f400-1cd0-11e9-9133-f6299bda8089.png)
![delete_meetup_screenshot](https://user-images.githubusercontent.com/46051026/51439808-a182f400-1cd0-11e9-8873-0809cda8f741.png)
